### PR TITLE
docs(user): 문체의 통일감을 저해하는 이모티콘 삭제

### DIFF
--- a/docs/user-guides/PKS-101.md
+++ b/docs/user-guides/PKS-101.md
@@ -35,7 +35,7 @@ PKS (PoolC Kubernetes Service)는 PoolC 동아리원이 자유롭게 이용할 �
 > 사용자 가이드 [README](./README.md)의 모든 설정을 마친 이후에 아래 가이드를 따라와 주세요. 특히 YSVPN이
 > 활성화되어 있어야 합니다!
 
-Nginx를 배포하고 이것저것 수정해보면서, PKS와 친해지는 시간을 가져봅시다. :D
+Nginx를 배포하고 이것저것 수정해보면서, PKS와 친해지는 시간을 가져봅시다!
 
 ### Step 1. Nginx 배포하기
 


### PR DESCRIPTION
":D" 이모티콘을 삭제하고, 느낌표를 사용해 감탄문을 작성합니다.

":D"와 같은 표현은 문서의 신뢰성을 떨어뜨릴 수 있고, 기술 문서에서 일반적으로 사용되는 문체와 어울리지 않습니다.

참조: https://github.com/PoolC/PKS-docs/pull/7#discussion_r2357788727