### PR TITLE
docs(user): Ingress 리소스 중복 오류 관련 FAQ 추가

### DIFF
--- a/docs/user-guides/FAQ.md
+++ b/docs/user-guides/FAQ.md
@@ -9,3 +9,28 @@
 
 [클러스터 접근용 토큰을 재설정](./README.md#클러스터-접속용-토큰-업데이트)하거나, 외부에서 접속하는 경우 YSVPN이
 활성화되었는지 다시 한번 확인해주세요.
+
+## 2. Ingress 리소스 생성이 안 돼요!
+
+아래와 유사한 오류가 발생하며 Ingress 리소스가 생성되지 않는다면, 누군가가 이미 사용 중인 host 및 path 조합으로
+Ingress 리소스를 생성하려고 했기 때문입니다.
+
+```text
+Error from server (BadRequest):
+error when creating "foo.yaml":
+admission webhook "validate.nginx.ingress.kubernetes.io" denied the request:
+host "ci-cd.demo.dev.poolc.org" and path "/" is already defined in ingress pks-argocd-demo/demo-server
+```
+
+Ingress를 생성하기 이전에는 `kubectl get ingress -A` 명령어를 통해 현재 사용 중인 도메인 이름을 확인한 뒤,
+중복되지 않는 값을 사용해주세요.
+
+```console
+$ kubectl get ingress -A
+NAMESPACE         NAME                            CLASS   HOSTS                             ADDRESS      PORTS   AGE
+argocd            argocd-server                   nginx   argocd.dev.poolc.org              10.99.76.2   80      88d
+argocd            argocd-server-grpc              nginx   grpc.argocd.dev.poolc.org         10.99.76.2   80      88d
+default           domain-routing-ingress          nginx   a.dev.poolc.org,b.dev.poolc.org   10.99.76.2   80      104d
+monitoring        kube-prometheus-stack-grafana   nginx   mon.dev.poolc.org                 10.99.76.2   80      47h
+pks-argocd-demo   demo-server                     nginx   ci-cd.demo.dev.poolc.org          10.99.76.2   80      35d
+```


### PR DESCRIPTION
Ingress 리소스 생성 시 host 및 path 중복으로 인해 발생하는 오류와 해결 방법을 FAQ에 정리합니다.

사용자 가이드의 예시 도메인을 그대로 사용할 경우, 다수의 사용자가 동일한 Ingress
host/path 조합을 생성하여 리소스 충돌이 발생하게 됩니다. 문서의 각종 실습에서 중복되지 않는 서브도메인 사용을 강조하고 있지만, 사용자가 해당 내용을 놓치는 경우를 대비해 FAQ에 관련 내용을 추가해 혼란을 방지합니다.