### PR TITLE
docs: README 문서 모음 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ PKS (Poolc Kubernetes Service)는 PoolC 동아리원을 위한 내부 쿠버네�
 
 PKS는 2024년 11월 30일, PoolC 홈커밍 행사 중 최유찬 회원과 양정일(@jjungs7) 회원의 비공식적인 대화에서 출발했습니다. 이후 양정일 회원과 양제성(@J3m3) 회원 간의 논의를 기점으로 초기 구상이 구체화되기 시작했고, 진영민(@jimmy0006) 회원이 합류하면서 개발이 본격화되었습니다. 초기 기여자 여러분들께 감사드립니다!
 
+## 문서 모음
+
+- [사용자 가이드](https://github.com/PoolC/PKS-docs/tree/main/docs/user-guides)
+- [운영자 가이드](./docs/admin-guide.md)
+- [PKS에 기여하기](./docs/contributing.md)
+- [아키텍처 개요](./docs/architecture.md)
+- [하드웨어 스펙](./docs/hw-spec.md)
+- [TODO list](./docs/todo.md)
+
 ## 개발 취지
 
 PKS는 다음과 같은 고민에서 시작됐습니다.
@@ -30,15 +39,6 @@ PKS는 다음과 같은 고민에서 시작됐습니다.
 이렇게 PKS는 동아리원이 함께 실습하고, 배포하고, 운영해볼 수 있는 쿠버네티스 기반의 공용 인프라를 구축하려는 시도에서 출발했습니다. 거창하게 여러 말을 붙였지만, 결국 PKS의 목표는 단순합니다.
 
 **_"동아리원이 안심하고 터뜨려도 되는, 마음껏 갖고 놀 수 있는 장난감."_**
-
-## 문서 모음
-
-- [아키텍처 개요](./docs/architecture.md)
-- [사용자 가이드](./docs/user-guides/README.md)
-- [운영자 가이드](./docs/admin-guide.md)
-- [PKS에 기여하기](./docs/contributing.md)
-- [하드웨어 스펙](./docs/hw-spec.md)
-- [TODO list](./docs/todo.md)
 
 ## 관련 레포지토리
 


### PR DESCRIPTION
- 문서 링크에 대한 접근성을 높이기 위해, '문서 모음' 섹션을 '개발 취지' 섹션 상단으로 이동합니다.
- 가장 많이 접속될 것으로 예상되는 사용자 가이드 문서에 대한 링크를 리스트의 최상단으로 이동합니다.