### PR TITLE
style: markdownlint 설정값 적용

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,291 @@
+# The original version is retrieved from:
+#   https://github.com/DavidAnson/markdownlint/blob/v0.38.0/schema/.markdownlint.yaml
+
+# Default state for all rules
+default: true
+
+# Path to configuration file to extend
+extends: null
+
+# MD001/heading-increment : Heading levels should only increment by one level at a time : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md001.md
+MD001: true
+
+# MD003/heading-style : Heading style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md003.md
+MD003:
+  # Heading style
+  style: "consistent"
+
+# MD004/ul-style : Unordered list style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md004.md
+MD004:
+  # List style
+  style: "consistent"
+
+# MD005/list-indent : Inconsistent indentation for list items at the same level : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md005.md
+MD005: true
+
+# MD007/ul-indent : Unordered list indentation : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md007.md
+MD007:
+  # Spaces for indent
+  indent: 2
+  # Whether to indent the first level of the list
+  start_indented: false
+  # Spaces for first level indent (when start_indented is set)
+  start_indent: 2
+
+# MD009/no-trailing-spaces : Trailing spaces : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md009.md
+MD009:
+  # Spaces for line break
+  br_spaces: 2
+  # Allow spaces for empty lines in list items
+  list_item_empty_lines: false
+  # Include unnecessary breaks
+  strict: false
+
+# MD010/no-hard-tabs : Hard tabs : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md010.md
+MD010:
+  # Include code blocks
+  code_blocks: true
+  # Fenced code languages to ignore
+  ignore_code_languages: []
+  # Number of spaces for each hard tab
+  spaces_per_tab: 1
+
+# MD011/no-reversed-links : Reversed link syntax : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md011.md
+MD011: true
+
+# MD012/no-multiple-blanks : Multiple consecutive blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md012.md
+MD012:
+  # Consecutive blank lines
+  maximum: 1
+
+# MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md013.md
+MD013:
+  # Number of characters
+  line_length: 80
+  # Number of characters for headings
+  heading_line_length: 80
+  # Include code blocks
+  code_blocks: false
+  # Include tables
+  tables: false
+  # Include headings
+  headings: true
+  # Strict length checking
+  strict: false
+  # Stern length checking
+  stern: false
+
+# MD014/commands-show-output : Dollar signs used before commands without showing output : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md014.md
+MD014: true
+
+# MD018/no-missing-space-atx : No space after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md018.md
+MD018: true
+
+# MD019/no-multiple-space-atx : Multiple spaces after hash on atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md019.md
+MD019: true
+
+# MD020/no-missing-space-closed-atx : No space inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md020.md
+MD020: true
+
+# MD021/no-multiple-space-closed-atx : Multiple spaces inside hashes on closed atx style heading : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md021.md
+MD021: true
+
+# MD022/blanks-around-headings : Headings should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md022.md
+MD022:
+  # Blank lines above heading
+  lines_above: 1
+  # Blank lines below heading
+  lines_below: 1
+
+# MD023/heading-start-left : Headings must start at the beginning of the line : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md023.md
+MD023: true
+
+# MD024/no-duplicate-heading : Multiple headings with the same content : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md024.md
+MD024:
+  # Only check sibling headings
+  siblings_only: true
+
+# MD025/single-title/single-h1 : Multiple top-level headings in the same document : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md025.md
+MD025:
+  # RegExp for matching title in front matter
+  front_matter_title: "^\\s*title\\s*[:=]"
+  # Heading level
+  level: 1
+
+# MD026/no-trailing-punctuation : Trailing punctuation in heading : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md026.md
+MD026:
+  # Punctuation characters
+  punctuation: ".,;:。，；：！"
+
+# MD027/no-multiple-space-blockquote : Multiple spaces after blockquote symbol : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md027.md
+MD027:
+  # Include list items
+  list_items: true
+
+# MD028/no-blanks-blockquote : Blank line inside blockquote : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md028.md
+MD028: true
+
+# MD029/ol-prefix : Ordered list item prefix : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md029.md
+MD029:
+  # List style
+  style: "one_or_ordered"
+
+# MD030/list-marker-space : Spaces after list markers : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md030.md
+MD030:
+  # Spaces for single-line unordered list items
+  ul_single: 1
+  # Spaces for single-line ordered list items
+  ol_single: 1
+  # Spaces for multi-line unordered list items
+  ul_multi: 1
+  # Spaces for multi-line ordered list items
+  ol_multi: 1
+
+# MD031/blanks-around-fences : Fenced code blocks should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md031.md
+MD031:
+  # Include list items
+  list_items: true
+
+# MD032/blanks-around-lists : Lists should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md032.md
+MD032: true
+
+# MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md033.md
+MD033:
+  # Allowed elements
+  allowed_elements:
+    - "a"
+    - "img"
+    - "p"
+    - "span"
+
+# MD034/no-bare-urls : Bare URL used : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md034.md
+MD034: true
+
+# MD035/hr-style : Horizontal rule style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md035.md
+MD035:
+  # Horizontal rule style
+  style: "consistent"
+
+# MD036/no-emphasis-as-heading : Emphasis used instead of a heading : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md036.md
+MD036:
+  # Punctuation characters
+  punctuation: ".,;:!?。，；：！？"
+
+# MD037/no-space-in-emphasis : Spaces inside emphasis markers : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md037.md
+MD037: true
+
+# MD038/no-space-in-code : Spaces inside code span elements : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md038.md
+MD038: true
+
+# MD039/no-space-in-links : Spaces inside link text : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md039.md
+MD039: true
+
+# MD040/fenced-code-language : Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md040.md
+MD040:
+  # List of languages
+  allowed_languages: []
+  # Require language only
+  language_only: false
+
+# MD041/first-line-heading/first-line-h1 : First line in a file should be a top-level heading : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md041.md
+MD041:
+  # Allow content before first heading
+  allow_preamble: false
+  # RegExp for matching title in front matter
+  front_matter_title: "^\\s*title\\s*[:=]"
+  # Heading level
+  level: 1
+
+# MD042/no-empty-links : No empty links : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md042.md
+MD042: true
+
+# MD044/proper-names : Proper names should have the correct capitalization : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md044.md
+MD044:
+  # List of proper names
+  names: []
+  # Include code blocks
+  code_blocks: true
+  # Include HTML elements
+  html_elements: true
+
+# MD045/no-alt-text : Images should have alternate text (alt text) : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md045.md
+MD045: true
+
+# MD046/code-block-style : Code block style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md046.md
+MD046:
+  # Block style
+  style: "consistent"
+
+# MD047/single-trailing-newline : Files should end with a single newline character : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md047.md
+MD047: true
+
+# MD048/code-fence-style : Code fence style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md048.md
+MD048:
+  # Code fence style
+  style: "consistent"
+
+# MD049/emphasis-style : Emphasis style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md049.md
+MD049:
+  # Emphasis style
+  style: "consistent"
+
+# MD050/strong-style : Strong style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md050.md
+MD050:
+  # Strong style
+  style: "consistent"
+
+# MD051/link-fragments : Link fragments should be valid : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md051.md
+MD051:
+  # Ignore case of fragments
+  ignore_case: false
+  # Pattern for ignoring additional fragments
+  ignored_pattern: ""
+
+# MD052/reference-links-images : Reference links and images should use a label that is defined : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md052.md
+MD052:
+  # Ignored link labels
+  ignored_labels:
+    - "x"
+  # Include shortcut syntax
+  shortcut_syntax: false
+
+# MD053/link-image-reference-definitions : Link and image reference definitions should be needed : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md053.md
+MD053:
+  # Ignored definitions
+  ignored_definitions:
+    - "//"
+
+# MD054/link-image-style : Link and image style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md054.md
+MD054:
+  # Allow autolinks
+  autolink: true
+  # Allow inline links and images
+  inline: true
+  # Allow full reference links and images
+  full: true
+  # Allow collapsed reference links and images
+  collapsed: true
+  # Allow shortcut reference links and images
+  shortcut: true
+  # Allow URLs as inline links
+  url_inline: true
+
+# MD055/table-pipe-style : Table pipe style : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md055.md
+MD055:
+  # Table pipe style
+  style: "consistent"
+
+# MD056/table-column-count : Table column count : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md056.md
+MD056: true
+
+# MD058/blanks-around-tables : Tables should be surrounded by blank lines : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md058.md
+MD058: true
+
+# MD059/descriptive-link-text : Link text should be descriptive : https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md059.md
+MD059:
+  # Prohibited link texts
+  prohibited_texts:
+    - "click here"
+    - "here"
+    - "link"
+    - "more"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 PKS (Poolc Kubernetes Service)는 PoolC 동아리원을 위한 내부 쿠버네티스 서비스입니다.
 
-PKS는 2024년 11월 30일, PoolC 홈커밍 행사 중 최유찬 회원과 양정일(@jjungs7) 회원의 비공식적인 대화에서 출발했습니다. 이후 양정일 회원과 양제성(@J3m3) 회원 간의 논의를 기점으로 초기 구상이 구체화되기 시작했고, 진영민(@jimmy0006) 회원이 합류하면서 개발이 본격화되었습니다. 초기 기여자 여러분들께 감사드립니다!
+PKS는 2024년 11월 30일, PoolC 홈커밍 행사 중 최유찬 회원과 양정일(@jjungs7) 회원의 비공식적인 대화에서
+출발했습니다. 이후 양정일 회원과 양제성(@J3m3) 회원 간의 논의를 기점으로 초기 구상이 구체화되기 시작했고,
+진영민(@jimmy0006) 회원이 합류하면서 개발이 본격화되었습니다. 초기 기여자 여러분들께 감사드립니다!
 
 ## 문서 모음
 
@@ -27,15 +29,18 @@ PKS는 다음과 같은 고민에서 시작됐습니다.
 
 > "씁... 없으면 만들면 되는 거 아닌가?"
 
-이렇게 PKS는 동아리원이 함께 실습하고, 배포하고, 운영해볼 수 있는 쿠버네티스 기반의 공용 인프라를 구축하려는 시도에서 출발했습니다. 거창하게 여러 말을 붙였지만, 결국 PKS의 목표는 단순합니다.
+이렇게 PKS는 동아리원이 함께 실습하고, 배포하고, 운영해볼 수 있는 쿠버네티스 기반의 공용 인프라를 구축하려는 시도에서
+출발했습니다. 거창하게 여러 말을 붙였지만, 결국 PKS의 목표는 단순합니다.
 
 **_"동아리원이 안심하고 터뜨려도 되는, 마음껏 갖고 놀 수 있는 장난감."_**
 
 ## 관련 레포지토리
 
 - PKS 세미나: TBD
-- [PKS Credentials Updater](https://github.com/PoolC/pks-credentials-updater): PKS 클러스터의 유저 정보를 일정 주기로 PoolC API 서버와 동기화하는 어플리케이션
-- [PKS Bootstrapping](https://github.com/PoolC/pks-bootstrapping): PKS 클러스터 부트스트래핑을 위한 manifest 모음
+- [PKS Credentials Updater](https://github.com/PoolC/pks-credentials-updater):
+  PKS 클러스터의 유저 정보를 일정 주기로 PoolC API 서버와 동기화하는 어플리케이션
+- [PKS Bootstrapping](https://github.com/PoolC/pks-bootstrapping):
+  PKS 클러스터 부트스트래핑을 위한 manifest 모음
 
 ## Special Thanks To
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,19 +14,19 @@ flowchart TB
     direction TB
 
     subgraph Services[" "]
-	    direction TB
+      direction TB
       ArgoCD["Argo CD<br/>(GitOps Operator)"]
       Ingress["ingress-nginx"]
       AppSvc["Application"]
     end
 
-	  subgraph PhysicalNodes["Physical Nodes"]
-	    direction TB
-	    Node1["Node1<br/>Control Plane + Worker"]
-	    Node2["Node2<br/>Control Plane + Worker"]
-	    Node3["Node3<br/>Control Plane + Worker"]
-	  end
-	end
+    subgraph PhysicalNodes["Physical Nodes"]
+      direction TB
+      Node1["Node1<br/>Control Plane + Worker"]
+      Node2["Node2<br/>Control Plane + Worker"]
+      Node3["Node3<br/>Control Plane + Worker"]
+    end
+  end
 
   PhysicalNodes -->|run| Services
 

--- a/docs/hw-spec.md
+++ b/docs/hw-spec.md
@@ -19,9 +19,9 @@ TODO: 전원 어댑터 정보 추가
 > 구매했었으나, 2025년 8월 25일 기준 4500U 옵션이 비활성화된 상태입니다. 구매일인 2025년 5월 18일
 > 기준 정가는 한화로 156,000원이었습니다.
 
-- Mini PC: https://www.texhoo.com/?ConsumerPC/56.html
-- RAM: https://prod.danawa.com/info/?pcode=11787154
-- SSD: https://prod.danawa.com/info/?pcode=19826411
+- Mini PC: <https://www.texhoo.com/?ConsumerPC/56.html>
+- RAM: <https://prod.danawa.com/info/?pcode=11787154>
+- SSD: <https://prod.danawa.com/info/?pcode=19826411>
 
 ## 사진
 

--- a/docs/user-guides/ArgoCD.md
+++ b/docs/user-guides/ArgoCD.md
@@ -415,8 +415,8 @@ git commit -m "chore(ci): add workflow for CI/CD"
      <span>"PoolC" organization에서 레포지토리 이름으로 "pks-argocd-demo"를 사용한 예시</span>
    </p>
 
-5. GitHub Packages Container Registry에 `deployment.yaml`이 참조하고 있는 이미지가 올바르게 업로드된 것을
-   확인할 수 있습니다.
+5. GitHub Packages Container Registry에 `deployment.yaml`이 참조하고 있는 이미지가 올바르게 업로드된
+   것을 확인할 수 있습니다.
 
    <p align="center">
      <img alt="A link to the package" src="../../assets/argocd-packages.webp">
@@ -445,7 +445,8 @@ git commit -m "chore(ci): add workflow for CI/CD"
 
    ![Creating a new app in Argo CD web UI](../../assets/argocd-web-new-app.webp)
 
-3. <a id="edit-using-ui">"GENERAL" 설정값을 입력합니다. "Application Name"을 제외한 나머지는 이미지와 동일하게 설정해주세요.</a>
+3. <a id="edit-using-ui">"GENERAL" 설정값을 입력합니다. "Application Name"을 제외한 나머지는 이미지와
+   동일하게 설정해주세요.</a>
 
    `kubectl get applications -A` 명령어를 통해서도 전체 Application 목록을 확인할 수 있습니다.
    알파벳 소문자와 "-"만으로 이루어진 이름을 사용해주세요.
@@ -455,7 +456,8 @@ git commit -m "chore(ci): add workflow for CI/CD"
      <span>"Application Name"으로 "pks-argocd-demo"를 사용한 예시</span>
    </p>
 
-4. <a id="edit-using-ui-ns">"SOURCE"와 "DESTINATION" 설정값을 입력합니다. "Namespace"를 제외한 나머지는 이미지와 동일하게
+4. <a id="edit-using-ui-ns">"SOURCE"와 "DESTINATION" 설정값을 입력합니다. "Namespace"를 제외한
+   나머지는 이미지와 동일하게
    설정해주세요. 설정을 완료한 뒤 "CREATE"를 클릭해주세요.</a>
 
    `kubectl get ns` 명령어로 전체 Namespace 목록을 확인할 수 있습니다.
@@ -471,6 +473,7 @@ git commit -m "chore(ci): add workflow for CI/CD"
 > 설정값을 정의하므로, 입력란을 하나하나 작성하지 않아도 됩니다. 더 자세한 내용은 부록의
 > [Argo CD의 Application manifest](#argo-cd의-application-manifest)를 참조해주세요.
 
+<!-- markdownlint-disable-next-line ol-prefix -->
 5. 상세 보기를 통해 Application의 상태 및 하위 리소스를 확인할 수 있습니다.
 
    ![Argo CD Applications tiles](../../assets/argocd-web-app-tiles.webp)
@@ -479,6 +482,7 @@ git commit -m "chore(ci): add workflow for CI/CD"
      <span>"Application Name" 및 "Namespace"로 "pks-argocd-demo"를 사용한 예시</span>
    </p>
 
+<!-- markdownlint-disable-next-line ol-prefix -->
 6. 상세 보기 화면에서 배포한 Python 웹 서버에 접속해볼 수 있습니다.
 
    <p align="center">
@@ -619,8 +623,8 @@ Argo CD web UI의 "EDIT AS YAML" 기능을 이용해 Application 리소스에 �
 
 ### GitHub Actions가 무엇인가요?
 
-> GitHub Actions is a continuous integration and continuous delivery (CI/CD) platform that
-> allows you to automate your build, test, and deployment pipeline.
+> GitHub Actions is a continuous integration and continuous delivery (CI/CD)
+> platform that allows you to automate your build, test, and deployment pipeline.
 >
 > -- [Understanding GitHub Actions](https://docs.github.com/en/actions/get-started/understand-github-actions#overview)
 

--- a/docs/user-guides/PKS-101.md
+++ b/docs/user-guides/PKS-101.md
@@ -165,7 +165,7 @@ EOF
 
 정상적으로 실행이 완료되었다면, 아래와 유사한 로그가 출력되어야 합니다.
 
-```
+```text
 namespace/$NAMESPACE_NAME created
 Waiting for RoleBinding to be created...
 configmap/my-html created
@@ -181,8 +181,7 @@ ingress.networking.k8s.io/my-ingress created
 
 <p align="center">
     <!-- TODO: 이미지 에셋 디렉토리 구조 변경 -->
-    <img src="../../assets/nginx-example.webp" />
-    <br />
+    <img alt="The default NGINX web page" src="../../assets/nginx-example.webp" />
     <span>"coffee"를 서브 도메인으로 사용한 예시</span>
 </p>
 
@@ -193,7 +192,7 @@ ingress.networking.k8s.io/my-ingress created
 
 로그 내용에서 확인할 수 있듯, 쿠버네티스는 알아서 변경된 리소스만을 업데이트합니다.
 
-```
+```text
 namespace/$NAMESPACE_NAME unchanged
 Waiting for RoleBinding to be created...
 configmap/my-html configured
@@ -297,14 +296,14 @@ spec:
 라는 기능이 있습니다.
 [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/),
 [Service](https://kubernetes.io/docs/concepts/services-networking/service/),
-[Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) 등과 같은 리소스들은
-이러한 Namespace 하위에 생성할 수 있으며, Namespace 내에서 각 리소스는 유일한 이름을 가져야 합니다. 즉
-`ns-a` Namespace에 `deploy-a`라는 Deployment가 존재한다면, `deploy-a`라는 이름을 갖는 새로운
+[Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) 등과 같은
+리소스들은 이러한 Namespace 하위에 생성할 수 있으며, Namespace 내에서 각 리소스는 유일한 이름을 가져야 합니다.
+즉 `ns-a` Namespace에 `deploy-a`라는 Deployment가 존재한다면, `deploy-a`라는 이름을 갖는 새로운
 Deployment를 `ns-a`에서는 생성할 수 없습니다. 이러한 제한은 Namespace _내에서만_ 유효하며, 서로 다른
 Namespace에서는 동일한 이름의 리소스가 존재할 수 있습니다. 예를 들어, `deploy-a`라는 이름의 Deployment가
 서로 다른 `ns-a`, `ns-b` Namespace에 모두 존재할 수 있습니다. 이를 간단히 그림으로 표현하면 아래와 같습니다.
 
-```
+```text
 # ✅ 서로 다른 Namespace에서는 동일한 이름 사용 가능
 .---------------------------.  .---------------------------.
 |      Namespace: ns-a      |  |      Namespace: ns-b      |

--- a/docs/user-guides/README.md
+++ b/docs/user-guides/README.md
@@ -19,8 +19,8 @@
 PKS 클러스터는 연세대학교 사설망 내부에 설치되어 있습니다. 교내 네트워크(yonsei Wi-Fi, poolc-5g Wi-Fi 등)를
 이용하지 않고 **외부에서 접속하는 경우에 한해**, YSVPN을 이용해야 합니다. 정보통신처의
 [YSVPN 관련 공지사항](https://yis.yonsei.ac.kr/ics/service/PolicyApplyInfo.do)과
-[YSVPN 사용자 메뉴얼](https://ibook.yonsei.ac.kr/Viewer/ysvpn_user_manual)을 통해 각자의 환경에 맞게
-YSVPN을 설치해주세요.
+[YSVPN 사용자 메뉴얼](https://ibook.yonsei.ac.kr/Viewer/ysvpn_user_manual)을 통해 각자의 환경에
+맞게 YSVPN을 설치해주세요.
 
 ## 1. `kubectl` 바이너리 설치
 
@@ -61,8 +61,7 @@ choco install kubernetes-cli
 
 <p align="center">
     <!-- TODO: 이미지 에셋 디렉토리 구조 변경 -->
-    <img src="../../assets/windows.downloadkubernetes.com.webp" />
-    <br />
+    <img alt="Downloading kubectl binary for windows" src="../../assets/windows.downloadkubernetes.com.webp">
     <span>Windows에서 바이너리를 다운로드받는 예시</span>
 </p>
 
@@ -84,7 +83,7 @@ choco install kubernetes-cli
 
 4. 아래와 같이 오류 없이 명령어가 실행됐다면, 클러스터 접속을 위한 준비를 모두 마친 것입니다.
 
-   ```
+   ```text
    User "pks" set.
    Cluster "pks" set.
    Context "pks" created.
@@ -189,6 +188,6 @@ current-context: pks # `kubectl config use-context`를 통해 수정되는 부�
 더 자세한 정보는 아래 내용들을 참고해주세요!
 
 - `kubectl config help` 명령어 출력 결과
-- https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-- https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/
-- https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/#see-also
+- <https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/>
+- <https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/>
+- <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_config/#see-also>

--- a/docs/user-guides/kubectl-quick-ref.md
+++ b/docs/user-guides/kubectl-quick-ref.md
@@ -24,7 +24,7 @@
   - [로그 조회하기](#로그-조회하기)
 - [리소스 수정하기](#리소스-수정하기)
 - [리소스 삭제하기](#리소스-삭제하기)
-- [컨테이너에 접근하기](#컨테이너에-접근하기)
+- [컨테이너에서 명령어 실행하기](#컨테이너에서-명령어-실행하기)
 - [더 알아보기](#더-알아보기)
 
 ## 리소스 생성하기
@@ -101,9 +101,9 @@ kubectl describe -n argocd pod argocd-application-controller-0
 
 #### 참조
 
-- Nodes: https://kubernetes.io/docs/concepts/architecture/nodes/
-- Workloads: https://kubernetes.io/docs/concepts/workloads/
-- Service: https://kubernetes.io/docs/concepts/services-networking/service/
+- Nodes: <https://kubernetes.io/docs/concepts/architecture/nodes/>
+- Workloads: <https://kubernetes.io/docs/concepts/workloads/>
+- Service: <https://kubernetes.io/docs/concepts/services-networking/service/>
 
 ### 로그 조회하기
 
@@ -132,7 +132,7 @@ kubectl apply -f ./my-deployment.yaml
 
 ### 참조
 
-- Manifests: https://kubernetes.io/docs/concepts/overview/working-with-objects/#describing-a-kubernetes-object
+- Manifests: <https://kubernetes.io/docs/concepts/overview/working-with-objects/#describing-a-kubernetes-object>
 
 ## 리소스 삭제하기
 

--- a/docs/user-guides/monitoring.md
+++ b/docs/user-guides/monitoring.md
@@ -1,8 +1,10 @@
 # PKS에서 내 애플리케이션 관찰하기
 
-PKS(PoolC Kubernetes Service)는 Grafana를 이용한 모니터링 대시보드를 제공하여, 사용자가 배포한 애플리케이션의 로그와 성능지표를 쉽게 확인하고 분석할 수 있도록 돕습니다.
+PKS(PoolC Kubernetes Service)는 Grafana를 이용한 모니터링 대시보드를 제공하여, 사용자가 배포한 애플리케이션의
+로그와 성능지표를 쉽게 확인하고 분석할 수 있도록 돕습니다.
 
-이 문서는 PKS에 간단한 웹 서버를 배포하고, Grafana 대시보드를 통해 해당 서버에서 발생하는 로그와 성능지표를 실시간으로 확인하는 과정을 안내합니다.
+이 문서는 PKS에 간단한 웹 서버를 배포하고, Grafana 대시보드를 통해 해당 서버에서 발생하는 로그와 성능지표를
+실시간으로 확인하는 과정을 안내합니다.
 
 ## 목차
 
@@ -23,7 +25,8 @@ PKS(PoolC Kubernetes Service)는 Grafana를 이용한 모니터링 대시보드�
 
 ## Disclaimer
 
-이 문서는 **PKS의 모니터링 기능을 빠르게 사용해보는 데에 초점**이 맞춰져 있습니다. Grafana의 모든 기능이나 로그 파이프라인의 상세한 동작 원리는 다루지 않습니다.
+이 문서는 **PKS의 모니터링 기능을 빠르게 사용해보는 데에 초점**이 맞춰져 있습니다. Grafana의 모든 기능이나 로그
+파이프라인의 상세한 동작 원리는 다루지 않습니다.
 
 ## 0. 실습 환경 구성
 
@@ -90,7 +93,9 @@ poolc-users          Active   33h
 4. 수정이 완료된 스크립트를 터미널에 그대로 붙여넣어 실행해주세요.
 
 > [!NOTE]
-> PKS에 배포되는 워크로드들은 dev.poolc.org의 하위 도메인을 **서로 겹치지 않는 선에서** 자유롭게 사용할 수 있습니다. `kubectl get ingress --all-namespaces` 명령어로 현재 사용 중인 도메인을 확인하고, 중복되지 않는 이름을 사용해주세요.
+> PKS에 배포되는 워크로드들은 dev.poolc.org의 하위 도메인을 **서로 겹치지 않는 선에서** 자유롭게 사용할 수
+> 있습니다. `kubectl get ingress --all-namespaces` 명령어로 현재 사용 중인 도메인을 확인하고, 중복되지
+> 않는 이름을 사용해주세요.
 
 ```sh
 NAMESPACE_NAME="my-monitoring-test"
@@ -186,6 +191,7 @@ spec:
 EOF
 ```
 
+<!-- markdownlint-disable-next-line ol-prefix -->
 5. 다음의 명령어를 사용해서 리소스가 잘 생성되었는지 확인해봅시다.
 
 ```console
@@ -210,7 +216,8 @@ replicaset.apps/nginx-deployment-698d9748f5   1         1         1       23m
 
 #### 로그 생성하기
 
-먼저, 아래 명령어를 실행하거나 웹 브라우저에서 `$SUBDOMAIN_NAME`.dev.poolc.org 주소로 접속하여 로그를 생성해주세요. 여러 번 접속하면 더 많은 로그를 확인할 수 있습니다.
+먼저, 아래 명령어를 실행하거나 웹 브라우저에서 `$SUBDOMAIN_NAME`.dev.poolc.org 주소로 접속하여 로그를
+생성해주세요. 여러 번 접속하면 더 많은 로그를 확인할 수 있습니다.
 
 ```sh
 curl $SUBDOMAIN_NAME.dev.poolc.org
@@ -218,7 +225,8 @@ curl $SUBDOMAIN_NAME.dev.poolc.org
 
 #### Grafana에서 로그 확인하기
 
-1. 모니터링 페이지([http://mon.dev.poolc.org](http://mon.dev.poolc.org))에 접속한 뒤, 좌측 메뉴에서 "Dashboards" 클릭하기
+1. 모니터링 페이지([http://mon.dev.poolc.org](http://mon.dev.poolc.org))에 접속한 뒤, 좌측 메뉴에서
+   "Dashboards" 클릭하기
 
    <p align="center">
      <img alt="grafana main page" src="../../assets/user_main.webp" />
@@ -227,11 +235,11 @@ curl $SUBDOMAIN_NAME.dev.poolc.org
 2. "Filter by tags" 기능으로 "logs" 태그가 포함된 대시보드 필터링하기
 
    <p align="center">
-       <img alt="a dashboard using filter" src="../../assets/user_dashboard_filter.webp" />
+       <img alt="a dashboard using filter" src="../../assets/user_dashboard_filter.webp">
    </p>
 
    <p align="center">
-       <img alt="a dashboard filtered with logs" src="../../assets/user_dashboard_logs.webp" />
+       <img alt="a dashboard filtered with logs" src="../../assets/user_dashboard_logs.webp">
    </p>
 
 3. Logs / App 대시보드에서 Pod 로그 확인하기
@@ -240,11 +248,12 @@ curl $SUBDOMAIN_NAME.dev.poolc.org
    - "namespace" 필터에서 방금 생성한 네임스페이스를 선택하면, 컨테이너가 출력하는 로그를 확인할 수 있습니다.
 
    <p align="center">
-       <img alt="An app log dashboard for Argo CD" src="../../assets/user_dashboard_logs_app.webp" />
+       <img alt="An app log dashboard for Argo CD" src="../../assets/user_dashboard_logs_app.webp">
        <span> "argocd"를 네임스페이스로 사용한 예시</span>
    </p>
 
-   ① Label Filters: 로그를 필터링하는 데 사용되는 레이블 선택 창입니다. "namespace", "pod" 등의 값을 지정하여 원하는 로그만 선택적으로 조회할 수 있습니다.
+   ① Label Filters: 로그를 필터링하는 데 사용되는 레이블 선택 창입니다. "namespace", "pod" 등의 값을 지정하여
+   원하는 로그만 선택적으로 조회할 수 있습니다.
 
    ② Time Range: 조회할 로그의 시간 범위를 설정하는 기능입니다.
 
@@ -256,16 +265,19 @@ curl $SUBDOMAIN_NAME.dev.poolc.org
 
 4. Logs / Ingress-NGINX 대시보드에서 Ingress NGINX 로그 확인하기
 
-   이 대시보드는 [Ingress NGINX](#ingress-nginx가-무엇인가요)를 통해 PKS 클러스터 내부로 전달한 요청의 [access log](#애플리케이션-로그와-access-로그의-차이)를 보여줍니다.
+   이 대시보드는 [Ingress NGINX](#ingress-nginx가-무엇인가요)를 통해 PKS 클러스터 내부로 전달한 요청의
+   [access log](#애플리케이션-로그와-access-로그의-차이)를 보여줍니다.
 
-   - "namespace"와 "service" 필터를 알맞게 선택하면, 우리가 생성한 웹 서버(`$SUBDOMAIN_NAME`.dev.poolc.org)로 들어온 요청 기록을 확인할 수 있습니다.
+   - "namespace"와 "service" 필터를 알맞게 선택하면, 우리가 생성한
+     웹 서버(`$SUBDOMAIN_NAME`.dev.poolc.org)로 들어온 요청 기록을 확인할 수 있습니다.
 
    <p align="center">
-       <img alt="An ingress-nginx log dashboard for Argo CD" src="../../assets/user_dashboard_logs_ingress.webp" />
+       <img alt="An ingress-nginx log dashboard for Argo CD" src="../../assets/user_dashboard_logs_ingress.webp">
        <span> "argocd"를 네임스페이스로 사용한 예시</span>
    </p>
 
-   ① Label Filters: Ingress NGINX 로그를 필터링하기 위한 레이블 선택 창입니다. 트래픽이 전달된 "namespace"와 "service"를 기준으로 특정 서비스의 접근 기록만 조회할 수 있습니다.
+   ① Label Filters: Ingress NGINX 로그를 필터링하기 위한 레이블 선택 창입니다. 트래픽이 전달된 "namespace"와
+   "service"를 기준으로 특정 서비스의 접근 기록만 조회할 수 있습니다.
 
    ② Time Range: 조회할 로그의 시간 범위를 설정하는 기능입니다.
 
@@ -311,32 +323,39 @@ curl $SUBDOMAIN_NAME.dev.poolc.org
 
 #### Grafana에서 Metric 확인하기
 
-1. Grafana의 Dashboards 중 "Kubernetes / Compute Resources / Namespace (Pods)" 대시보드를 선택합니다.
+1. Grafana의 Dashboards 중 "Kubernetes / Compute Resources / Namespace (Pods)"
+   대시보드를 선택합니다.
 
 2. 대시보드 상단의 "Namespace" 필터에서 [Step 1](#step-1-nginx-배포하기)에서 생성한 자신의 네임스페이스를 선택합니다.
 
 3. `ab` 명령어로 부하를 가하면, 아래 이미지와 같이 CPU 사용량이 급증하는 것을 실시간으로 관찰할 수 있습니다.
 
    <p align="center">
-       <img alt="Dashboard under stress" src="../../assets/user_dashboard_stress.webp" />
+       <img alt="Dashboard under stress" src="../../assets/user_dashboard_stress.webp">
        <span>부하 테스트 중인 대시보드 상태</span>
    </p>
 
    ① Label Filters: 생성한 네임스페이스를 선택하여 해당 워크로드의 상태만 필터링해서 볼 수 있습니다.
 
    ② 성능 요약 패널: ([자세히 알아보기](#쿠버네티스-리소스resources-설정하기))
-     - CPU Utilization (from requests): 파드가 요청(requests)한 CPU 양 대비 현재 사용량을 나타냅니다. 182%라는 것은 요청량보다 1.82배 많은 CPU를 사용하고 있음을 의미합니다.
-     - CPU Utilization (from limits): 파드가 사용할 수 있는 최대 CPU 양(limits) 대비 현재 사용량을 나타냅니다. 91.2%로, 설정된 한계치에 가깝게 CPU를 사용하고 있음을 보여줍니다.
-     - Memory Utilization (from requests): 파드가 요청(requests)한 Memory 양 대비 현재 사용량을 나타냅니다.
-     - Memory Utilization (from limits): 파드가 사용할 수 있는 최대 Memory 양(limits) 대비 현재 사용량을 나타냅니다.
+     - CPU Utilization (from requests): 파드가 요청(requests)한 CPU 양 대비 현재 사용량을 나타냅니다.
+       182%라는 것은 요청량보다 1.82배 많은 CPU를 사용하고 있음을 의미합니다.
+     - CPU Utilization (from limits): 파드가 사용할 수 있는 최대 CPU 양(limits) 대비 현재 사용량을
+       나타냅니다. 91.2%로, 설정된 한계치에 가깝게 CPU를 사용하고 있음을 보여줍니다.
+     - Memory Utilization (from requests): 파드가 요청(requests)한 Memory 양 대비 현재 사용량을
+       나타냅니다.
+     - Memory Utilization (from limits): 파드가 사용할 수 있는 최대 Memory 양(limits) 대비 현재
+       사용량을 나타냅니다.
 
    ③ 상세 그래프:
      - CPU Usage: ab 명령어로 부하를 주는 동안 시간의 흐름에 따라 CPU 사용량이 꾸준히 증가하는 것을 확인할 수 있습니다.
-     - Memory Usage: 이번 실습에서는 CPU에 비해 메모리 사용량 변화는 크지 않지만, 애플리케이션의 특징에 따라 메모리 사용량도 이곳에서 모니터링할 수 있습니다.
+     - Memory Usage: 이번 실습에서는 CPU에 비해 메모리 사용량 변화는 크지 않지만, 애플리케이션의 특징에 따라 메모리
+       사용량도 이곳에서 모니터링할 수 있습니다.
 
 ### Step 4. 실습 완료 후 모든 자원 삭제하기
 
-실습이 끝났다면, 아래 명령어를 실행하여 생성했던 모든 리소스를 한 번에 삭제할 수 있습니다. `$NAMESPACE_NAME` 부분은 [Step 1](#step-1-nginx-배포하기)에서 지정한 이름으로 변경해주세요.
+실습이 끝났다면, 아래 명령어를 실행하여 생성했던 모든 리소스를 한 번에 삭제할 수 있습니다. `$NAMESPACE_NAME` 부분은
+[Step 1](#step-1-nginx-배포하기)에서 지정한 이름으로 변경해주세요.
 
 ```sh
 kubectl delete namespace $NAMESPACE_NAME
@@ -350,22 +369,32 @@ kubectl delete namespace $NAMESPACE_NAME
 
 ### Grafana가 무엇인가요?
 
-Grafana는 다양한 데이터 소스로부터 시계열 데이터를 가져와 시각화해주는 오픈소스 대시보드 툴입니다. PKS에서는 클러스터의 각종 로그와 메트릭 정보를 Grafana 대시보드를 통해 제공하여, 사용자가 자신의 워크로드 상태를 직관적으로 파악할 수 있도록 돕습니다.
+Grafana는 다양한 데이터 소스로부터 시계열 데이터를 가져와 시각화해주는 오픈소스 대시보드 툴입니다. PKS에서는 클러스터의
+각종 로그와 메트릭 정보를 Grafana 대시보드를 통해 제공하여, 사용자가 자신의 워크로드 상태를 직관적으로 파악할 수 있도록
+돕습니다.
 
 ### Ingress NGINX가 무엇인가요?
 
-Ingress NGINX는 클러스터로 들어오는 HTTP/HTTPS 요청을 내부의 어떤 서비스로 전달할지 정의하는 Ingress 규칙을 실행하는 컨트롤러입니다. 이 문서의 실습에서 사용자가 YAML로 Ingress 리소스를 생성한 것이 바로 이 "라우팅 규칙"을 정의한 것입니다.
+Ingress NGINX는 클러스터로 들어오는 HTTP/HTTPS 요청을 내부의 어떤 서비스로 전달할지 정의하는 Ingress 규칙을
+실행하는 컨트롤러입니다. 이 문서의 실습에서 사용자가 YAML로 Ingress 리소스를 생성한 것이 바로 이 "라우팅 규칙"을 정의한
+것입니다.
 
-PKS에서는 Ingress NGINX가 요청을 내부의 서비스로 전달하므로, 어떤 요청이 언제 들어왔는지 기록하는 access log가 바로 이 Controller에서 생성됩니다.
+PKS에서는 Ingress NGINX가 요청을 내부의 서비스로 전달하므로, 어떤 요청이 언제 들어왔는지 기록하는 access log가 바로
+이 Controller에서 생성됩니다.
 
 ### 애플리케이션 로그와 access 로그의 차이
 
-- 애플리케이션 로그 (Logs / App): 컨테이너 내부에서 실행되는 애플리케이션이 직접 출력하는 로그입니다. `console.log`, `print` 문 등으로 출력하는 내용들이 여기에 해당하며, 애플리케이션의 내부 동작을 디버깅하는 데 주로 사용됩니다.
-- access 로그 (Logs / Ingress-NGINX): 클러스터로 들어오는 모든 HTTP/HTTPS 요청에 대한 기록입니다. 어떤 사용자가 언제, 어떤 주소로, 어떤 메소드(GET, POST 등)를 사용해 접속했는지 등의 정보를 담고 있어 트래픽 분석이나 접근 제어에 유용합니다.
+- 애플리케이션 로그 (Logs / App): 컨테이너 내부에서 실행되는 애플리케이션이 직접 출력하는 로그입니다.
+  `console.log`, `print` 문 등으로 출력하는 내용들이 여기에 해당하며, 애플리케이션의 내부 동작을 디버깅하는 데 주로
+  사용됩니다.
+- access 로그 (Logs / Ingress-NGINX): 클러스터로 들어오는 모든 HTTP/HTTPS 요청에 대한 기록입니다. 어떤
+  사용자가 언제, 어떤 주소로, 어떤 메소드(GET, POST 등)를 사용해 접속했는지 등의 정보를 담고 있어 트래픽 분석이나
+  접근 제어에 유용합니다.
 
 ### 쿠버네티스 리소스(Resources) 설정하기
 
-[쿠버네티스 리소스(Resources) 설정](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)은 컨테이너가 사용할 CPU와 메모리 양을 정하는 규칙입니다.
+[쿠버네티스 리소스(Resources) 설정](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)은
+컨테이너가 사용할 CPU와 메모리 양을 정하는 규칙입니다.
 
 문서에서 사용된 예시를 다시 한번 살펴봅시다.
 
@@ -385,7 +414,8 @@ resources:
 - `cpu: "50m"`: CPU 성능을 최소 0.05코어 보장받습니다.
 - `memory: "64Mi"`: 메모리를 최소 64MiB는 확보합니다.
 
-`limits`: 컨테이너가 사용할 수 있는 리소스의 최댓값을 설정합니다. 컨테이너가 `cpu` limit에 할당된 양을 모두 사용하면 쓰로틀링이 발생하며, `memory` limit을 초과하면 out of memory (OOM)로 인해 강제로 종료될 수 있습니다.
+`limits`: 컨테이너가 사용할 수 있는 리소스의 최댓값을 설정합니다. 컨테이너가 `cpu` limit에 할당된 양을 모두 사용하면
+쓰로틀링이 발생하며, `memory` limit을 초과하면 out of memory (OOM)로 인해 강제로 종료될 수 있습니다.
 
 - `cpu: "100m"`: CPU를 최대 0.1코어까지만 사용하도록 제한합니다.
 - `memory: "128Mi"`: 메모리를 최대 128MiB까지만 사용하도록 제한합니다.


### PR DESCRIPTION
v0.38.0의 기본 설정값 [1]을 바탕으로 아래의 변경사항을 적용해 전체 문서를 포맷팅합니다.

가독성 향상을 위해 적용한 변경사항:
- 코드 블록과 테이블에 대한 `line_length` 제한을 해제합니다.

유의미한 이점 없이 필요 이상으로 제한적인 규칙 완화:
- 서로 다른 parent를 갖는 헤딩 제목이 중복되는 것을 허용합니다.
- 헤딩의 끝 부분에 느낌표(!)를 사용할 수 있도록 허용합니다.
- `a`, `p`, `img`, `span` 태그를 사용한 인라인 HTML을 허용합니다.
- 헤딩 형식을 강제하는 규칙을 삭제합니다.

참조:
- [1] https://github.com/DavidAnson/markdownlint/blob/v0.38.0/schema/.markdownlint.yaml

Closes: #8
Closes: #10