### PR TITLE
ci: 마크다운 파일의 linting 이슈를 확인하는 workflow 추가

### DIFF
--- a/.github/workflows/lint-markdown.yaml
+++ b/.github/workflows/lint-markdown.yaml
@@ -1,0 +1,40 @@
+name: Check markdown linting issues
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**/*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      # The changed-files action automatically fetches more history of the
+      # current PR branch.
+      # See:
+      # - https://github.com/tj-actions/changed-files/blob/24d32ffd492484c1d75e0c0b894501ddb9d30d62/src/commitSha.ts#L115-L166
+      - name: Get all changed markdown files
+        id: changed-markdown-files
+        uses: tj-actions/changed-files@v47
+        with:
+          files: "**/*.md"
+          separator: ","
+
+      - name: Run markdownlint
+        if: steps.changed-markdown-files.outputs.any_changed == 'true'
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        continue-on-error: false
+        with:
+          globs: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
+          separator: ","
+          config: .markdownlint.yaml


### PR DESCRIPTION
Pull request 생성 시 변경된 마크다운 파일의 linting 이슈를 자동으로 검사하는 GitHub Actions workflow를 추가합니다. 이를 통해 기여자는 리뷰 요청 전에 스타일 문제를 미리 수정할 수 있고, 리뷰어는 내용 검토에만 집중하여 리뷰 효율성을 높일 수 있습니다.

Depends on #18